### PR TITLE
chore: Use custom special-purpose SSH key for rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ Then add the missing values to the files: username, ip or URLs, directory paths 
 - `sudo apt update`
 - `sudo apt install rsync inotify-tools`
 
-3. Set up SSH key-based authentication between your desktop and the remote machine:
-- `ssh-keygen -t ed25519`
-- `ssh-copy-id user@server`
+3. Set up SSH key-based authentication between your desktop and the remote machine. Use these instructions to set up a special-purpose SSH key that is only allowed to execute rsync-related commands on the remote server.
+- `ssh-keygen -t ed25519 -N "" -f ~/.ssh/rsync-triton-vm`
+- `cat ~/.ssh/rsync-triton-vm.pub` and copy the public key (the entire line).
+- On the remove server, add the following line to `~/.ssh/authorized_keys`:
+
+```
+command="/usr/bin/rrsync /var/www/triton-vm-proofs",no-agent-forwarding,no-port-forwarding,no-pty ssh-ed25519 AAA... user@desktop-name; rsync-only key
+```
 
 4. Make the `watch_and_sync_script.sh` script executable
 - `chmod +x ~/bin/watch_and_sync.sh`
@@ -51,7 +56,7 @@ Then add the missing values to the files: username, ip or URLs, directory paths 
 11. Add your ssh user to group www-data so it can write proof files
 - `sudo usermod -g www-data <user>`
 
-Other relevant commands
+#### Other relevant commands
 Check log of proof-syncing service, on workstation
 - `journalctl -u sync-triton-vm-proofs.service -f`
 

--- a/workstation-files/watch_and_sync.sh
+++ b/workstation-files/watch_and_sync.sh
@@ -5,5 +5,5 @@
 inotifywait -m -r -e create -e moved_to <neptune-core-directory>/test_data/ |
 while read path action file; do
     echo "New file detected: $file. Syncing..."
-    rsync -avz --ignore-existing --no-perms --no-group --no-times <neptune-core-directory>/test_data/ <user>@<ip-or-url-of-server>:/var/www/triton-vm-proofs/
+    rsync -avz -e "ssh -i /home/<user>/.ssh/rsync-triton-vm" --ignore-existing --no-perms --no-group --no-times <neptune-core-directory>/test_data/ <user>@<ip-or-url-of-server>:/var/www/triton-vm-proofs/
 done


### PR DESCRIPTION
The reason why you want to use a custom SSH key:
 - it cannot be password-protected, or scripts will fail;
 - you want to limit what SSH keys can do when they do not have password protection.

This commit modifies the `README.md` and `watch_and_sync.sh` accordingly.